### PR TITLE
Remove monolog dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   "require": {
     "php": ">=8.1.0",
     "guzzlehttp/guzzle": "~7.0",
-    "guzzlehttp/guzzle-services": "~1.0",
-    "monolog/monolog": "^2.7"
+    "guzzlehttp/guzzle-services": "~1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Monolog is not a required dependency for the package.
If you will try to install `maib/maibapi` in a laravel 10+ project you will get an error:
```bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - laravel/framework[v10.0.0, ..., v10.14.1] require monolog/monolog ^3.0 -> satisfiable by monolog/monolog[3.0.0, ..., 3.4.0].
    - You can only install one version of a package, so only one of these can be installed: monolog/monolog[2.7.0, 2.8.0, 2.9.0, 2.9.1, 3.0.0, ..., 3.4.0].
    - maib/maibapi[3.0.0, ..., 3.0.4] require monolog/monolog ^2.7 -> satisfiable by monolog/monolog[2.7.0, 2.8.0, 2.9.0, 2.9.1].
    - Root composer.json requires maib/maibapi ^3.0 -> satisfiable by maib/maibapi[3.0.0, ..., 3.0.4].
    - Root composer.json requires laravel/framework ^10.0 -> satisfiable by laravel/framework[v10.0.0, ..., v10.14.1].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.
```