### PR TITLE
Fixes #11 Min PHP version too high in 3.* releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1.0",
+    "php": "^7.2.5 || ^8.0",
     "guzzlehttp/guzzle": "~7.0",
     "guzzlehttp/guzzle-services": "~1.0"
   },


### PR DESCRIPTION
Fixes #11 

Synchronizes minimum required PHP version to Guzzle `composer.json` https://github.com/guzzle/guzzle/blob/7.8/composer.json#L82

```json
"require": {
    "php": "^7.2.5 || ^8.0",
```